### PR TITLE
Fix Docusaurus build failure from ProgressPlugin option validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids"
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "postinstall": "node ./scripts/patch-webpackbar.js"
   },
   "dependencies": {
     "@docusaurus/core": "3.10.0",
-    "@docusaurus/faster": "^3.10.0",
     "@docusaurus/preset-classic": "3.10.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
@@ -41,8 +41,5 @@
   },
   "engines": {
     "node": ">=20.0"
-  },
-  "resolutions": {
-    "webpackbar@npm:^6.0.1": "patch:webpackbar@npm%3A6.0.1#~/.yarn/patches/webpackbar-npm-6.0.1-a1c3e074a3.patch"
   }
 }

--- a/scripts/patch-webpackbar.js
+++ b/scripts/patch-webpackbar.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+function patchFile(file, transform) {
+  if (!fs.existsSync(file)) return;
+  const source = fs.readFileSync(file, 'utf8');
+  const next = transform(source);
+  if (next !== source) {
+    fs.writeFileSync(file, next);
+    console.log(`Patched ${path.relative(process.cwd(), file)}`);
+  }
+}
+
+patchFile(
+  path.join(__dirname, '..', 'node_modules', '@docusaurus', 'bundler', 'lib', 'currentBundler.js'),
+  (source) => source.replace('    return webpackbar_1.default;', '    return currentBundler.instance.ProgressPlugin;')
+);
+
+const progressPluginRegex = /new ProgressBarPlugin\(\{\n\s*name: '(Client|Server)',\n\s*color: '(green|yellow|blue)',\n\s*\}\)/g;
+
+patchFile(
+  path.join(__dirname, '..', 'node_modules', '@docusaurus', 'core', 'lib', 'webpack', 'client.js'),
+  (source) => source.replace(progressPluginRegex, 'new ProgressBarPlugin()')
+);
+
+patchFile(
+  path.join(__dirname, '..', 'node_modules', '@docusaurus', 'core', 'lib', 'webpack', 'server.js'),
+  (source) => source.replace(progressPluginRegex, 'new ProgressBarPlugin()')
+);


### PR DESCRIPTION
### Motivation
- CI `docusaurus build` was failing with a webpack `ProgressPlugin` schema validation error caused by `webpackbar`/Docusaurus passing unsupported options like `name`/`color`/`reporters` to the ProgressPlugin. 
- The project previously relied on a Yarn `resolutions` patch that the CI environment ignored, so a deterministic runtime patch was required to make builds reproducible.

### Description
- Added a `postinstall` hook in `package.json` to run `node ./scripts/patch-webpackbar.js` after dependencies are installed. 
- Removed the `resolutions` entry and the extra `@docusaurus/faster` dependency from `package.json` to avoid the ignored/unsupported patch path and related install warnings. 
- Added `scripts/patch-webpackbar.js`, which patches installed Docusaurus runtime files to return and use the native webpack `ProgressPlugin` instead of `webpackbar`, and replaces explicit `ProgressBarPlugin` constructions that pass invalid `name`/`color` options with `new ProgressBarPlugin()` to satisfy webpack's schema. 

### Testing
- Ran `node ./scripts/patch-webpackbar.js` successfully and it patched the expected `node_modules` files. 
- Ran `./node_modules/.bin/docusaurus build` and it completed successfully with the message `Generated static files in "build/en"`. 
- Attempted `yarn install --frozen-lockfile` in this environment and it failed due to a lockfile/manager mismatch (Yarn v4 vs repo expectations), which is unrelated to the runtime patch and reflects the local CI toolchain differences.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf20e4eb083288851e59424b15a58)