### PR TITLE
ci: add concurrency guards to VietnamPlus, VOV and deploy workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
   # Review gh actions docs if you want to further define triggers, paths, etc
   # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: write
 

--- a/.github/workflows/vietnamplus.yml
+++ b/.github/workflows/vietnamplus.yml
@@ -2,6 +2,10 @@ name: "Cronjob VietnamPlus"
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   vietnamplus_job:
     name: VietnamPlus - ${{ matrix.rand_seed }}

--- a/.github/workflows/vov.yml
+++ b/.github/workflows/vov.yml
@@ -2,6 +2,10 @@ name: "Cronjob VOV"
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   vov_job:
     name: VOV - ${{ matrix.rand_seed }}


### PR DESCRIPTION
### Motivation
- The `VietnamPlus -> VOV -> Deploy` workflow chain can enqueue many runs when manually dispatched multiple times, causing queued/stacked jobs and wasted runner capacity. 
- Preventing stacked runs by cancelling in-progress older runs ensures only the latest dispatch for a given ref executes.

### Description
- Add a `concurrency` section with `group: ${{ github.workflow }}-${{ github.ref }}` and `cancel-in-progress: true` to `./.github/workflows/vietnamplus.yml`. 
- Add the same `concurrency` section to `./.github/workflows/vov.yml`. 
- Add the same `concurrency` section to `./.github/workflows/deploy.yml` (the `Deploy to GitHub Pages` workflow).

### Testing
- Ran `git diff --check` and it completed with no issues. 
- Attempted to parse the modified workflow YAMLs with `python -c "import yaml; ..."` but parsing failed because the environment lacks the `yaml` module (automated validation not available in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def80becb48328aa97ca0ace9f42ae)