### PR TITLE
ci: prevent duplicate GitHub Actions executions

### DIFF
--- a/.github/workflows/baochinhphu.yml
+++ b/.github/workflows/baochinhphu.yml
@@ -2,11 +2,17 @@ name: "Cronjob BaoChinhPhu"
 on:
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   baochinhphu_job:
     name: BaoChinhPhu - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - feed_list: "https://baochinhphu.vn/home.rss"

--- a/.github/workflows/dantri.yml
+++ b/.github/workflows/dantri.yml
@@ -2,11 +2,17 @@ name: "Cronjob DanTri"
 on:
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dantri_job:
     name: Dân Trí - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - feed_list: "https://dantri.com.vn/rss/home.rss"

--- a/.github/workflows/hoahoctro.yml
+++ b/.github/workflows/hoahoctro.yml
@@ -2,11 +2,17 @@ name: "Cronjob HoaHocTro"
 on:
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   hoahoctro_job:
     name: HoaHocTro - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - feed_list: "https://hoahoctro.tienphong.vn/rss/home.rss"

--- a/.github/workflows/laodong.yml
+++ b/.github/workflows/laodong.yml
@@ -2,11 +2,17 @@ name: "Cronjob LaoDong"
 on:
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   laodong_job:
     name: Lao Động - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - feed_list: "https://laodong.vn/rss/home.rss"

--- a/.github/workflows/muctim.yml
+++ b/.github/workflows/muctim.yml
@@ -2,11 +2,17 @@ name: "Cronjob MucTim"
 on:
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   muctim_job:
     name: MucTim - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - feed_list: "https://muctim.tuoitre.vn/rss/home.rss"

--- a/.github/workflows/news.yml
+++ b/.github/workflows/news.yml
@@ -6,11 +6,17 @@ on:
   #   branches:
   #     - "main"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-homepages:
     name: Get ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - feed_list: "https://vnexpress.net/rss/tin-moi-nhat.rss"

--- a/.github/workflows/nhandan.yml
+++ b/.github/workflows/nhandan.yml
@@ -2,11 +2,17 @@ name: "Cronjob NhanDan"
 on:
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   nhandan_job:
     name: Nhân Dân - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - feed_list: "https://nhandan.vn/rss/home.rss"

--- a/.github/workflows/nld.yml
+++ b/.github/workflows/nld.yml
@@ -2,11 +2,17 @@ name: "Cronjob NLD"
 on:
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   nld_job:
     name: Người Lao Động - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - feed_list: "https://nld.com.vn/rss/home.rss"

--- a/.github/workflows/sggp.yml
+++ b/.github/workflows/sggp.yml
@@ -2,11 +2,17 @@ name: "Cronjob SGGP"
 on:
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sggp_job:
     name: SGGP - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - feed_list: "https://www.sggp.org.vn/rss/home.rss"

--- a/.github/workflows/thanhnien.yml
+++ b/.github/workflows/thanhnien.yml
@@ -2,11 +2,17 @@ name: "Cronjob ThanhNien"
 on:
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   thanhnien_job:
     name: Thanh Niên - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - feed_list: "https://thanhnien.vn/rss/home.rss"

--- a/.github/workflows/thuvienphapluat.yml
+++ b/.github/workflows/thuvienphapluat.yml
@@ -2,11 +2,17 @@ name: "Cronjob ThuVienPhapLuat"
 on:
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   thuvienphapluat_job:
     name: Thư Viện Pháp Luật - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - feed_list: "https://thuvienphapluat.vn/rss.xml"

--- a/.github/workflows/tuoitre.yml
+++ b/.github/workflows/tuoitre.yml
@@ -2,11 +2,17 @@ name: "Cronjob TuoiTre"
 on:
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tuoitre_job:
     name: Tuổi Trẻ - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - feed_list: "https://tuoitre.vn/rss/tin-moi-nhat.rss"

--- a/.github/workflows/vietnamplus.yml
+++ b/.github/workflows/vietnamplus.yml
@@ -11,6 +11,7 @@ jobs:
     name: VietnamPlus - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - feed_list: "https://www.vietnamplus.vn/rss/tin-moi.rss"

--- a/.github/workflows/vnexpress.yml
+++ b/.github/workflows/vnexpress.yml
@@ -4,11 +4,17 @@ on:
     - cron: "*/30 * * * *"
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   vnexpress_job:
     name: VnExpress - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - feed_list: "https://vnexpress.net/rss/tin-moi-nhat.rss"

--- a/.github/workflows/vov.yml
+++ b/.github/workflows/vov.yml
@@ -11,6 +11,7 @@ jobs:
     name: VOV - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - feed_list: "https://vov.vn/rss/home.rss"

--- a/.github/workflows/vtc.yml
+++ b/.github/workflows/vtc.yml
@@ -2,11 +2,17 @@ name: "Cronjob VTC"
 on:
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   vnexpress:
     name: VTC - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - feed_list: "https://vtc.vn/rss/feed.rss"


### PR DESCRIPTION
### Motivation
- Prevent concurrent or duplicate GitHub Actions runs for the RSS cron workflows so that only one run per workflow/ref is active and older runs are cancelled. 
- Avoid spawning many parallel matrix jobs when updating multiple feeds to reduce load and ensure feed updates run sequentially.
- Keep the existing chained/trigger behavior intact while making executions deterministic and safe.

### Description
- Added a top-level `concurrency` block to each RSS-related workflow to set `group: ${{ github.workflow }}-${{ github.ref }}` and `cancel-in-progress: true` so new runs cancel in-progress runs. 
- Added `strategy: max-parallel: 1` to matrix jobs in those workflows so matrix entries execute sequentially instead of in parallel. 
- Changes were applied across the RSS workflows under `.github/workflows/` (16 files updated, e.g. `news.yml`, `vnexpress.yml`, `dantri.yml`, `vov.yml`, `vietnamplus.yml`, `tuoitre.yml`, `nhandan.yml`, `nld.yml`, `laodong.yml`, `baochinhphu.yml`, `sggp.yml`, `thanhnien.yml`, `thuvienphapluat.yml`, `muctim.yml`, `hoahoctro.yml`, `vtc.yml`).

### Testing
- Verified all modified workflow YAML files parse with `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each{|f| YAML.load_file(f)}; puts "workflow yaml ok"'` which succeeded. 
- Ran `git diff --check` which returned no whitespace or formatting errors. 
- Confirmed inserted keys by grepping the workflows with `rg -n "^concurrency:|max-parallel" .github/workflows` which showed the new `concurrency` and `max-parallel: 1` entries in each updated file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def9e02098832882c9caf2c851c119)