### PR TITLE
Switch blog-post-workflow references to `ePlus-DEV/blog-post-workflow@v1` in workflows

### DIFF
--- a/.github/workflows/baochinhphu.yml
+++ b/.github/workflows/baochinhphu.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Pull in BaoChinhPhu news
-        uses: ePlus-DEV/blog-post-workflow@v1.0.2
+        uses: ePlus-DEV/blog-post-workflow@v1
         with:
           retry_count: 5
           readme_path: ${{ matrix.readme_path }}

--- a/.github/workflows/dantri.yml
+++ b/.github/workflows/dantri.yml
@@ -108,7 +108,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Pull in DanTri news
-        uses: ePlus-DEV/blog-post-workflow@v1.0.2
+        uses: ePlus-DEV/blog-post-workflow@v1
         with:
           retry_count: 5
           readme_path: ${{ matrix.readme_path }}

--- a/.github/workflows/hoahoctro.yml
+++ b/.github/workflows/hoahoctro.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Pull in HoaHocTro news
-        uses: ePlus-DEV/blog-post-workflow@v1.0.2
+        uses: ePlus-DEV/blog-post-workflow@v1
         with:
           retry_count: 5
           readme_path: ${{ matrix.readme_path }}

--- a/.github/workflows/laodong.yml
+++ b/.github/workflows/laodong.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Pull in LaoDong news
-        uses: ePlus-DEV/blog-post-workflow@v1.0.2
+        uses: ePlus-DEV/blog-post-workflow@v1
         with:
           retry_count: 5
           readme_path: ${{ matrix.readme_path }}

--- a/.github/workflows/muctim.yml
+++ b/.github/workflows/muctim.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Pull in MucTim news
-        uses: ePlus-DEV/blog-post-workflow@v1.0.2
+        uses: ePlus-DEV/blog-post-workflow@v1
         with:
           retry_count: 5
           readme_path: ${{ matrix.readme_path }}

--- a/.github/workflows/news.yml
+++ b/.github/workflows/news.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Pull changes from the remote repository
         run: git pull origin main
       - name: Pull in news
-        uses: ePlus-DEV/blog-post-workflow@v1.0.1
+        uses: ePlus-DEV/blog-post-workflow@v1
         with:
           retry_count: 5
           readme_path: ./docs/index.md

--- a/.github/workflows/nhandan.yml
+++ b/.github/workflows/nhandan.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Pull in NhanDan news
-        uses: ePlus-DEV/blog-post-workflow@v1.0.2
+        uses: ePlus-DEV/blog-post-workflow@v1
         with:
           retry_count: 5
           readme_path: ${{ matrix.readme_path }}

--- a/.github/workflows/nld.yml
+++ b/.github/workflows/nld.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Pull in NLD news
-        uses: ePlus-DEV/blog-post-workflow@v1.0.2
+        uses: ePlus-DEV/blog-post-workflow@v1
         with:
           retry_count: 5
           readme_path: ${{ matrix.readme_path }}

--- a/.github/workflows/sggp.yml
+++ b/.github/workflows/sggp.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Pull in SGGP news
-        uses: ePlus-DEV/blog-post-workflow@v1.0.2
+        uses: ePlus-DEV/blog-post-workflow@v1
         with:
           retry_count: 5
           readme_path: ${{ matrix.readme_path }}

--- a/.github/workflows/thanhnien.yml
+++ b/.github/workflows/thanhnien.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Pull in ThanhNien news
-        uses: ePlus-DEV/blog-post-workflow@v1.0.2
+        uses: ePlus-DEV/blog-post-workflow@v1
         with:
           retry_count: 5
           readme_path: ${{ matrix.readme_path }}

--- a/.github/workflows/thuvienphapluat.yml
+++ b/.github/workflows/thuvienphapluat.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Pull in Thư Viện Pháp Luật news
-        uses: ePlus-DEV/blog-post-workflow@v1.0.2
+        uses: ePlus-DEV/blog-post-workflow@v1
         with:
           retry_count: 5
           readme_path: ${{ matrix.readme_path }}

--- a/.github/workflows/tuoitre.yml
+++ b/.github/workflows/tuoitre.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Pull in TuoiTre news
-        uses: ePlus-DEV/blog-post-workflow@v1.0.2
+        uses: ePlus-DEV/blog-post-workflow@v1
         with:
           retry_count: 5
           readme_path: ${{ matrix.readme_path }}

--- a/.github/workflows/vietnamplus.yml
+++ b/.github/workflows/vietnamplus.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Pull in VietnamPlus news
-        uses: ePlus-DEV/blog-post-workflow@v1.0.2
+        uses: ePlus-DEV/blog-post-workflow@v1
         with:
           retry_count: 5
           readme_path: ${{ matrix.readme_path }}

--- a/.github/workflows/vnexpress.yml
+++ b/.github/workflows/vnexpress.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Pull in vnexpress news
-        uses: ePlus-DEV/blog-post-workflow@v1.0.2
+        uses: ePlus-DEV/blog-post-workflow@v1
         with:
           retry_count: 5
           readme_path: ${{ matrix.readme_path }}

--- a/.github/workflows/vov.yml
+++ b/.github/workflows/vov.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Pull in VOV news
-        uses: ePlus-DEV/blog-post-workflow@v1.0.2
+        uses: ePlus-DEV/blog-post-workflow@v1
         with:
           retry_count: 5
           readme_path: ${{ matrix.readme_path }}

--- a/.github/workflows/vtc.yml
+++ b/.github/workflows/vtc.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Pull in VTC news
-        uses: ePlus-DEV/blog-post-workflow@v1.0.2
+        uses: ePlus-DEV/blog-post-workflow@v1
         with:
           retry_count: 5
           readme_path: ${{ matrix.readme_path }}


### PR DESCRIPTION
### Motivation
- Standardize the action reference to the major `v1` tag so workflows pick up non-breaking fixes without requiring repeated workflow edits. 
- Replace pinned patch tags (`v1.0.1`, `v1.0.2`) to reduce maintenance overhead and keep behavior consistent across workflows.

### Description
- Updated all usages of `ePlus-DEV/blog-post-workflow@v1.0.2` and `@v1.0.1` to `ePlus-DEV/blog-post-workflow@v1` across the repository's workflows in `.github/workflows`.
- Files changed include `baochinhphu.yml`, `dantri.yml`, `hoahoctro.yml`, `laodong.yml`, `muctim.yml`, `news.yml`, `nhandan.yml`, `nld.yml`, `sggp.yml`, `thanhnien.yml`, `thuvienphapluat.yml`, `tuoitre.yml`, `vietnamplus.yml`, `vnexpress.yml`, `vov.yml`, and `vtc.yml`.
- No other job steps, inputs, or behavior were modified in this PR.

### Testing
- No automated tests were executed as part of this change; the updates are limited to workflow action references and will be exercised when GitHub Actions run the workflows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df02d304bc8328abc81c067f151dcf)