### PR TITLE
Thêm các trang báo có workflow GitHub Actions vào sidebar docs

### DIFF
--- a/docs/baochinhphu/_category_.json
+++ b/docs/baochinhphu/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Báo Chính Phủ",
+  "position": 9,
+  "link": {
+    "type": "generated-index",
+    "description": "Tin tức từ Báo Chính Phủ.",
+    "slug": "baochinhphu"
+  }
+}

--- a/docs/baochinhphu/tin-moi-nhat.md
+++ b/docs/baochinhphu/tin-moi-nhat.md
@@ -1,0 +1,8 @@
+---
+title: Tin mới nhất
+sidebar_position: 1
+---
+
+<!-- baochinhphu-tin-moi-nhat:START -->
+- Đang cập nhật dữ liệu...
+<!-- baochinhphu-tin-moi-nhat:END -->

--- a/docs/hoahoctro/_category_.json
+++ b/docs/hoahoctro/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Báo Hoa Học Trò",
+  "position": 12,
+  "link": {
+    "type": "generated-index",
+    "description": "Tin tức từ Báo Hoa Học Trò.",
+    "slug": "hoahoctro"
+  }
+}

--- a/docs/hoahoctro/tin-moi-nhat.md
+++ b/docs/hoahoctro/tin-moi-nhat.md
@@ -1,0 +1,8 @@
+---
+title: Tin mới nhất
+sidebar_position: 1
+---
+
+<!-- hoahoctro-tin-moi-nhat:START -->
+- Đang cập nhật dữ liệu...
+<!-- hoahoctro-tin-moi-nhat:END -->

--- a/docs/laodong/_category_.json
+++ b/docs/laodong/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Báo Lao Động",
+  "position": 5,
+  "link": {
+    "type": "generated-index",
+    "description": "Tin tức từ Báo Lao Động.",
+    "slug": "laodong"
+  }
+}

--- a/docs/laodong/tin-moi-nhat.md
+++ b/docs/laodong/tin-moi-nhat.md
@@ -1,0 +1,8 @@
+---
+title: Tin mới nhất
+sidebar_position: 1
+---
+
+<!-- laodong-tin-moi-nhat:START -->
+- Đang cập nhật dữ liệu...
+<!-- laodong-tin-moi-nhat:END -->

--- a/docs/muctim/_category_.json
+++ b/docs/muctim/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Báo Mực Tím",
+  "position": 11,
+  "link": {
+    "type": "generated-index",
+    "description": "Tin tức từ Báo Mực Tím.",
+    "slug": "muctim"
+  }
+}

--- a/docs/muctim/tin-moi-nhat.md
+++ b/docs/muctim/tin-moi-nhat.md
@@ -1,0 +1,8 @@
+---
+title: Tin mới nhất
+sidebar_position: 1
+---
+
+<!-- muctim-tin-moi-nhat:START -->
+- Đang cập nhật dữ liệu...
+<!-- muctim-tin-moi-nhat:END -->

--- a/docs/nhandan/_category_.json
+++ b/docs/nhandan/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Báo Nhân Dân",
-  "position": 4,
+  "position": 13,
   "link": {
     "type": "generated-index",
     "description": "Tin tức từ Báo Nhân Dân.",

--- a/docs/nld/_category_.json
+++ b/docs/nld/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Báo Người Lao Động",
+  "position": 6,
+  "link": {
+    "type": "generated-index",
+    "description": "Tin tức từ Báo Người Lao Động.",
+    "slug": "nld"
+  }
+}

--- a/docs/nld/tin-moi-nhat.md
+++ b/docs/nld/tin-moi-nhat.md
@@ -1,0 +1,8 @@
+---
+title: Tin mới nhất
+sidebar_position: 1
+---
+
+<!-- nld-tin-moi-nhat:START -->
+- Đang cập nhật dữ liệu...
+<!-- nld-tin-moi-nhat:END -->

--- a/docs/sggp/_category_.json
+++ b/docs/sggp/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Báo SGGP",
+  "position": 7,
+  "link": {
+    "type": "generated-index",
+    "description": "Tin tức từ Báo SGGP.",
+    "slug": "sggp"
+  }
+}

--- a/docs/sggp/tin-moi-nhat.md
+++ b/docs/sggp/tin-moi-nhat.md
@@ -1,0 +1,8 @@
+---
+title: Tin mới nhất
+sidebar_position: 1
+---
+
+<!-- sggp-tin-moi-nhat:START -->
+- Đang cập nhật dữ liệu...
+<!-- sggp-tin-moi-nhat:END -->

--- a/docs/thanhnien/_category_.json
+++ b/docs/thanhnien/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Báo Thanh Niên",
+  "position": 4,
+  "link": {
+    "type": "generated-index",
+    "description": "Tin tức từ Báo Thanh Niên.",
+    "slug": "thanhnien"
+  }
+}

--- a/docs/thanhnien/tin-moi-nhat.md
+++ b/docs/thanhnien/tin-moi-nhat.md
@@ -1,0 +1,8 @@
+---
+title: Tin mới nhất
+sidebar_position: 1
+---
+
+<!-- thanhnien-tin-moi-nhat:START -->
+- Đang cập nhật dữ liệu...
+<!-- thanhnien-tin-moi-nhat:END -->

--- a/docs/thuvienphapluat/_category_.json
+++ b/docs/thuvienphapluat/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Thư Viện Pháp Luật",
+  "position": 10,
+  "link": {
+    "type": "generated-index",
+    "description": "Tin tức từ Thư Viện Pháp Luật.",
+    "slug": "thuvienphapluat"
+  }
+}

--- a/docs/thuvienphapluat/tin-moi-nhat.md
+++ b/docs/thuvienphapluat/tin-moi-nhat.md
@@ -1,0 +1,8 @@
+---
+title: Tin mới nhất
+sidebar_position: 1
+---
+
+<!-- thuvienphapluat-tin-moi-nhat:START -->
+- Đang cập nhật dữ liệu...
+<!-- thuvienphapluat-tin-moi-nhat:END -->

--- a/docs/tuoitre/_category_.json
+++ b/docs/tuoitre/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Báo Tuổi Trẻ",
-  "position": 5,
+  "position": 14,
   "link": {
     "type": "generated-index",
     "description": "Tin tức từ Báo Tuổi Trẻ.",

--- a/docs/vietnamplus/_category_.json
+++ b/docs/vietnamplus/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Báo VietnamPlus",
-  "position": 6,
+  "position": 15,
   "link": {
     "type": "generated-index",
     "description": "Tin tức từ Báo VietnamPlus.",

--- a/docs/vov/_category_.json
+++ b/docs/vov/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Báo VOV",
-  "position": 7,
+  "position": 16,
   "link": {
     "type": "generated-index",
     "description": "Tin tức từ Báo VOV.",

--- a/docs/vtc/_category_.json
+++ b/docs/vtc/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Báo VTC",
+  "position": 8,
+  "link": {
+    "type": "generated-index",
+    "description": "Tin tức từ Báo VTC.",
+    "slug": "vtc"
+  }
+}

--- a/docs/vtc/tin-moi-nhat.md
+++ b/docs/vtc/tin-moi-nhat.md
@@ -1,0 +1,8 @@
+---
+title: Tin mới nhất
+sidebar_position: 1
+---
+
+<!-- vtc-tin-moi-nhat:START -->
+- Đang cập nhật dữ liệu...
+<!-- vtc-tin-moi-nhat:END -->


### PR DESCRIPTION
### Motivation
- Thêm các chuyên mục báo mà repository đã có GitHub Actions để các workflow tự động có chỗ cập nhật nội dung trong `docs` và hiển thị trên sidebar. 
- Giữ thứ tự hiển thị hợp lý trong sidebar khi bổ sung nhiều chuyên mục mới cùng lúc. 

### Description
- Tạo các thư mục chuyên mục và file chỉ mục cho các báo mới: `thanhnien`, `laodong`, `nld`, `sggp`, `vtc`, `baochinhphu`, `thuvienphapluat`, `muctim`, `hoahoctro` bằng file `docs/<site>/_category_.json` (mỗi file chứa `label`, `position`, `link`).
- Thêm trang placeholder `docs/<site>/tin-moi-nhat.md` cho mỗi chuyên mục với marker `<!-- <site>-tin-moi-nhat:START -->` / `<!-- <site>-tin-moi-nhat:END -->` để các workflow có thể cập nhật nội dung tự động. 
- Cập nhật `position` cho các chuyên mục hiện có (`nhandan`, `tuoitre`, `vietnamplus`, `vov`) để tránh trùng thứ tự khi thêm mục mới. 

### Testing
- Chạy site build với `npm run build` và quá trình build hoàn tất thành công; có các cảnh báo cũ của dự án (`blog` truncation) nhưng không làm fail build.
- Kiểm tra file mới tồn tại dưới `docs/` và các marker `<!-- ...:START -->`/`<!-- ...:END -->` đã được thêm vào để tương thích với workflow tự động.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df12834554832895ce00f87a404006)