### PR TITLE
Tune matrix RSS workflows for faster failures and better push-recovery

### DIFF
--- a/.github/workflows/baochinhphu.yml
+++ b/.github/workflows/baochinhphu.yml
@@ -12,7 +12,7 @@ jobs:
     name: BaoChinhPhu - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         include:
           - feed_list: "https://baochinhphu.vn/home.rss"
@@ -26,7 +26,9 @@ jobs:
       - name: Pull in BaoChinhPhu news
         uses: ePlus-DEV/blog-post-workflow@v1
         with:
-          retry_count: 5
+          retry_count: 1
+          request_timeout: 15
+          push_retry_count: 10
           readme_path: ${{ matrix.readme_path }}
           feed_list: ${{ matrix.feed_list }}
           committer_email: "h250694@gmail.com"

--- a/.github/workflows/dantri.yml
+++ b/.github/workflows/dantri.yml
@@ -12,7 +12,7 @@ jobs:
     name: Dân Trí - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         include:
           - feed_list: "https://dantri.com.vn/rss/home.rss"
@@ -110,7 +110,9 @@ jobs:
       - name: Pull in DanTri news
         uses: ePlus-DEV/blog-post-workflow@v1
         with:
-          retry_count: 5
+          retry_count: 1
+          request_timeout: 15
+          push_retry_count: 10
           readme_path: ${{ matrix.readme_path }}
           feed_list: ${{ matrix.feed_list }}
           committer_email: "h250694@gmail.com"

--- a/.github/workflows/hoahoctro.yml
+++ b/.github/workflows/hoahoctro.yml
@@ -12,7 +12,7 @@ jobs:
     name: HoaHocTro - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         include:
           - feed_list: "https://hoahoctro.tienphong.vn/rss/home.rss"
@@ -26,7 +26,9 @@ jobs:
       - name: Pull in HoaHocTro news
         uses: ePlus-DEV/blog-post-workflow@v1
         with:
-          retry_count: 5
+          retry_count: 1
+          request_timeout: 15
+          push_retry_count: 10
           readme_path: ${{ matrix.readme_path }}
           feed_list: ${{ matrix.feed_list }}
           committer_email: "h250694@gmail.com"

--- a/.github/workflows/laodong.yml
+++ b/.github/workflows/laodong.yml
@@ -12,7 +12,7 @@ jobs:
     name: Lao Động - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         include:
           - feed_list: "https://laodong.vn/rss/home.rss"
@@ -26,7 +26,9 @@ jobs:
       - name: Pull in LaoDong news
         uses: ePlus-DEV/blog-post-workflow@v1
         with:
-          retry_count: 5
+          retry_count: 1
+          request_timeout: 15
+          push_retry_count: 10
           readme_path: ${{ matrix.readme_path }}
           feed_list: ${{ matrix.feed_list }}
           committer_email: "h250694@gmail.com"

--- a/.github/workflows/muctim.yml
+++ b/.github/workflows/muctim.yml
@@ -12,7 +12,7 @@ jobs:
     name: MucTim - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         include:
           - feed_list: "https://muctim.tuoitre.vn/rss/home.rss"
@@ -26,7 +26,9 @@ jobs:
       - name: Pull in MucTim news
         uses: ePlus-DEV/blog-post-workflow@v1
         with:
-          retry_count: 5
+          retry_count: 1
+          request_timeout: 15
+          push_retry_count: 10
           readme_path: ${{ matrix.readme_path }}
           feed_list: ${{ matrix.feed_list }}
           committer_email: "h250694@gmail.com"

--- a/.github/workflows/news.yml
+++ b/.github/workflows/news.yml
@@ -16,7 +16,7 @@ jobs:
     name: Get ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         include:
           - feed_list: "https://vnexpress.net/rss/tin-moi-nhat.rss"
@@ -72,7 +72,9 @@ jobs:
       - name: Pull in news
         uses: ePlus-DEV/blog-post-workflow@v1
         with:
-          retry_count: 5
+          retry_count: 1
+          request_timeout: 15
+          push_retry_count: 10
           readme_path: ./docs/index.md
           feed_list: ${{ matrix.feed_list }}
           committer_email: "h250694@gmail.com"

--- a/.github/workflows/nhandan.yml
+++ b/.github/workflows/nhandan.yml
@@ -12,7 +12,7 @@ jobs:
     name: Nhân Dân - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         include:
           - feed_list: "https://nhandan.vn/rss/home.rss"
@@ -38,7 +38,9 @@ jobs:
       - name: Pull in NhanDan news
         uses: ePlus-DEV/blog-post-workflow@v1
         with:
-          retry_count: 5
+          retry_count: 1
+          request_timeout: 15
+          push_retry_count: 10
           readme_path: ${{ matrix.readme_path }}
           feed_list: ${{ matrix.feed_list }}
           committer_email: "h250694@gmail.com"

--- a/.github/workflows/nld.yml
+++ b/.github/workflows/nld.yml
@@ -12,7 +12,7 @@ jobs:
     name: Người Lao Động - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         include:
           - feed_list: "https://nld.com.vn/rss/home.rss"
@@ -95,7 +95,9 @@ jobs:
       - name: Pull in NLD news
         uses: ePlus-DEV/blog-post-workflow@v1
         with:
-          retry_count: 5
+          retry_count: 1
+          request_timeout: 15
+          push_retry_count: 10
           readme_path: ${{ matrix.readme_path }}
           feed_list: ${{ matrix.feed_list }}
           committer_email: "h250694@gmail.com"

--- a/.github/workflows/sggp.yml
+++ b/.github/workflows/sggp.yml
@@ -12,7 +12,7 @@ jobs:
     name: SGGP - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         include:
           - feed_list: "https://www.sggp.org.vn/rss/home.rss"
@@ -59,7 +59,9 @@ jobs:
       - name: Pull in SGGP news
         uses: ePlus-DEV/blog-post-workflow@v1
         with:
-          retry_count: 5
+          retry_count: 1
+          request_timeout: 15
+          push_retry_count: 10
           readme_path: ${{ matrix.readme_path }}
           feed_list: ${{ matrix.feed_list }}
           committer_email: "h250694@gmail.com"

--- a/.github/workflows/thanhnien.yml
+++ b/.github/workflows/thanhnien.yml
@@ -12,7 +12,7 @@ jobs:
     name: Thanh Niên - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         include:
           - feed_list: "https://thanhnien.vn/rss/home.rss"
@@ -95,7 +95,9 @@ jobs:
       - name: Pull in ThanhNien news
         uses: ePlus-DEV/blog-post-workflow@v1
         with:
-          retry_count: 5
+          retry_count: 1
+          request_timeout: 15
+          push_retry_count: 10
           readme_path: ${{ matrix.readme_path }}
           feed_list: ${{ matrix.feed_list }}
           committer_email: "h250694@gmail.com"

--- a/.github/workflows/thuvienphapluat.yml
+++ b/.github/workflows/thuvienphapluat.yml
@@ -12,7 +12,7 @@ jobs:
     name: Thư Viện Pháp Luật - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         include:
           - feed_list: "https://thuvienphapluat.vn/rss.xml"
@@ -26,7 +26,9 @@ jobs:
       - name: Pull in Thư Viện Pháp Luật news
         uses: ePlus-DEV/blog-post-workflow@v1
         with:
-          retry_count: 5
+          retry_count: 1
+          request_timeout: 15
+          push_retry_count: 10
           readme_path: ${{ matrix.readme_path }}
           feed_list: ${{ matrix.feed_list }}
           committer_email: "h250694@gmail.com"

--- a/.github/workflows/tuoitre.yml
+++ b/.github/workflows/tuoitre.yml
@@ -12,7 +12,7 @@ jobs:
     name: Tuổi Trẻ - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         include:
           - feed_list: "https://tuoitre.vn/rss/tin-moi-nhat.rss"
@@ -38,7 +38,9 @@ jobs:
       - name: Pull in TuoiTre news
         uses: ePlus-DEV/blog-post-workflow@v1
         with:
-          retry_count: 5
+          retry_count: 1
+          request_timeout: 15
+          push_retry_count: 10
           readme_path: ${{ matrix.readme_path }}
           feed_list: ${{ matrix.feed_list }}
           committer_email: "h250694@gmail.com"

--- a/.github/workflows/vietnamplus.yml
+++ b/.github/workflows/vietnamplus.yml
@@ -11,7 +11,7 @@ jobs:
     name: VietnamPlus - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         include:
           - feed_list: "https://www.vietnamplus.vn/rss/tin-moi.rss"
@@ -37,7 +37,9 @@ jobs:
       - name: Pull in VietnamPlus news
         uses: ePlus-DEV/blog-post-workflow@v1
         with:
-          retry_count: 5
+          retry_count: 1
+          request_timeout: 15
+          push_retry_count: 10
           readme_path: ${{ matrix.readme_path }}
           feed_list: ${{ matrix.feed_list }}
           committer_email: "h250694@gmail.com"

--- a/.github/workflows/vnexpress.yml
+++ b/.github/workflows/vnexpress.yml
@@ -14,7 +14,7 @@ jobs:
     name: VnExpress - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         include:
           - feed_list: "https://vnexpress.net/rss/tin-moi-nhat.rss"
@@ -61,7 +61,9 @@ jobs:
       - name: Pull in vnexpress news
         uses: ePlus-DEV/blog-post-workflow@v1
         with:
-          retry_count: 5
+          retry_count: 1
+          request_timeout: 15
+          push_retry_count: 10
           readme_path: ${{ matrix.readme_path }}
           feed_list: ${{ matrix.feed_list }}
           committer_email: "h250694@gmail.com"

--- a/.github/workflows/vov.yml
+++ b/.github/workflows/vov.yml
@@ -11,7 +11,7 @@ jobs:
     name: VOV - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         include:
           - feed_list: "https://vov.vn/rss/home.rss"
@@ -37,7 +37,9 @@ jobs:
       - name: Pull in VOV news
         uses: ePlus-DEV/blog-post-workflow@v1
         with:
-          retry_count: 5
+          retry_count: 1
+          request_timeout: 15
+          push_retry_count: 10
           readme_path: ${{ matrix.readme_path }}
           feed_list: ${{ matrix.feed_list }}
           committer_email: "h250694@gmail.com"

--- a/.github/workflows/vtc.yml
+++ b/.github/workflows/vtc.yml
@@ -12,7 +12,7 @@ jobs:
     name: VTC - ${{ matrix.rand_seed }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      fail-fast: false
       matrix:
         include:
           - feed_list: "https://vtc.vn/rss/feed.rss"
@@ -26,7 +26,9 @@ jobs:
       - name: Pull in VTC news
         uses: ePlus-DEV/blog-post-workflow@v1
         with:
-          retry_count: 5
+          retry_count: 1
+          request_timeout: 15
+          push_retry_count: 10
           readme_path: ${{ matrix.readme_path }}
           feed_list: ${{ matrix.feed_list }}
           committer_email: "h250694@gmail.com"


### PR DESCRIPTION
### Motivation
- Matrix RSS ingestion jobs were stalling on slow feeds due to high retry/backoff settings causing long per-feed waits. 
- The workflows should fail fast on slow endpoints and recover automatically from concurrent branch-push races. 
- Matrix execution should not cancel remaining entries when one feed fails so other feeds can continue to run.

### Description
- Replaced `max-parallel: 1` with `fail-fast: false` in the matrix `strategy` for RSS workflows to allow other matrix entries to continue independently. 
- Reduced the action input `retry_count` from `5` to `1` for `ePlus-DEV/blog-post-workflow@v1` to avoid long stalls per feed. 
- Added `request_timeout: 15` to force faster failures on slow RSS endpoints and added `push_retry_count: 10` to enable automatic recovery from branch update races. 
- Applied these changes across 16 workflow files under `.github/workflows/` (e.g., `news.yml`, `vnexpress.yml`, `dantri.yml`, `thanhnien.yml`, `laodong.yml`, `nld.yml`, `sggp.yml`, `vtc.yml`, `baochinhphu.yml`, `thuvienphapluat.yml`, `muctim.yml`, `hoahoctro.yml`, `nhandan.yml`, `tuoitre.yml`, `vietnamplus.yml`, `vov.yml`).

### Testing
- Ran `git diff --check` to ensure no whitespace or diff errors and it completed with no issues. 
- Verified the presence of updated keys with `rg -n "max-parallel|fail-fast|retry_count|request_timeout|push_retry_count" .github/workflows/*.yml -S` and confirmed the new settings are present in the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df3404d6ac83289b9ba805e083a36a)