### PR TITLE
Add newspaper-style blog UI and theme variables in custom.css

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -15,6 +15,15 @@
   --ifm-color-primary-lightest: #3cad6e;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+
+  --news-bg: #f5f7fb;
+  --news-surface: #ffffff;
+  --news-border: #d9e1ec;
+  --news-divider: #e5ecf5;
+  --news-title: #0f172a;
+  --news-body: #334155;
+  --news-meta: #60738a;
+  --news-shadow: 0 18px 30px -26px rgba(16, 24, 40, 0.65);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -27,4 +36,166 @@
   --ifm-color-primary-lighter: #32d8b4;
   --ifm-color-primary-lightest: #4fddbf;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+
+  --news-bg: #090f1a;
+  --news-surface: #101a2b;
+  --news-border: #1f2f45;
+  --news-divider: #1a293d;
+  --news-title: #f8fafc;
+  --news-body: #d1d9e6;
+  --news-meta: #93a4bb;
+  --news-shadow: 0 20px 36px -28px rgba(0, 0, 0, 0.8);
+}
+
+/* ---------- Blog UI: newspaper style ---------- */
+.blog-wrapper {
+  background: linear-gradient(180deg, var(--news-bg) 0%, var(--ifm-background-color) 220px);
+}
+
+.blog-list-page main,
+.blog-post-page main {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+.blog-list-page .container,
+.blog-post-page .container {
+  padding-top: 1.5rem;
+  padding-bottom: 2.5rem;
+}
+
+.blog-list-page article {
+  margin: 0;
+  border-bottom: 1px solid var(--news-divider);
+  padding: 1.4rem 0;
+}
+
+.blog-list-page article:first-of-type {
+  border-top: 1px solid var(--news-divider);
+}
+
+.blog-list-page article > .row {
+  margin: 0;
+}
+
+.blog-list-page article .col {
+  padding: 0;
+}
+
+.blog-list-page h2 {
+  margin: 0 0 0.65rem;
+}
+
+.blog-list-page h2 a {
+  color: var(--news-title);
+  font-size: clamp(1.3rem, 1.8vw, 1.9rem);
+  line-height: 1.22;
+  text-decoration: none;
+}
+
+.blog-list-page h2 a:hover {
+  color: var(--ifm-color-primary);
+}
+
+.blog-list-page p,
+.blog-post-page p {
+  color: var(--news-body);
+  font-size: 1.03rem;
+  line-height: 1.8;
+}
+
+.blog-list-page .margin-bottom--sm,
+.blog-post-page .margin-bottom--sm {
+  margin-bottom: 0.55rem !important;
+}
+
+.blog-list-page .avatar,
+.blog-post-page .avatar {
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.blog-list-page .avatar__name,
+.blog-list-page .avatar__subtitle,
+.blog-post-page .avatar__name,
+.blog-post-page .avatar__subtitle,
+.blog-post-page time {
+  color: var(--news-meta);
+}
+
+.blog-list-page .avatar__photo,
+.blog-post-page .avatar__photo {
+  border: 1px solid color-mix(in srgb, var(--ifm-color-primary) 40%, transparent);
+}
+
+.blog-post-page article {
+  border: 1px solid var(--news-border);
+  border-radius: 14px;
+  background: var(--news-surface);
+  box-shadow: var(--news-shadow);
+  padding: clamp(1.1rem, 2vw, 2.2rem);
+}
+
+.blog-post-page header {
+  border-bottom: 1px solid var(--news-divider);
+  padding-bottom: 0.95rem;
+  margin-bottom: 0.75rem;
+}
+
+.blog-post-page header h1 {
+  color: var(--news-title);
+  font-size: clamp(1.8rem, 3vw, 2.7rem);
+  line-height: 1.18;
+  margin: 0.4rem 0 0.2rem;
+}
+
+.blog-post-page .theme-doc-markdown {
+  margin-top: 1.25rem;
+}
+
+.blog-post-page .theme-doc-markdown h2,
+.blog-post-page .theme-doc-markdown h3,
+.blog-post-page .theme-doc-markdown h4 {
+  color: var(--news-title);
+  scroll-margin-top: 84px;
+}
+
+.blog-post-page blockquote {
+  border-left-color: var(--ifm-color-primary);
+  background: color-mix(in srgb, var(--ifm-color-primary) 8%, transparent);
+}
+
+.blog-list-page .pagination-nav,
+.blog-post-page .pagination-nav {
+  margin-top: 1.8rem;
+  gap: 0.85rem;
+}
+
+.blog-list-page .pagination-nav__link,
+.blog-post-page .pagination-nav__link {
+  border-radius: 12px;
+  border: 1px solid var(--news-border);
+  background: var(--news-surface);
+  box-shadow: var(--news-shadow);
+}
+
+@media (max-width: 996px) {
+  .blog-list-page .container,
+  .blog-post-page .container {
+    padding-top: 1rem;
+    padding-bottom: 2rem;
+  }
+
+  .blog-list-page article {
+    padding: 1rem 0;
+  }
+
+  .blog-list-page h2 a {
+    font-size: clamp(1.15rem, 4.9vw, 1.45rem);
+  }
+
+  .blog-post-page article {
+    border-radius: 10px;
+    padding: 1rem;
+  }
 }


### PR DESCRIPTION
### Motivation
- Introduce a refined, newspaper-style visual treatment for blog list and post pages to improve readability and visual hierarchy.
- Provide dedicated CSS variables for news-related colors, surfaces, borders, dividers, and shadows to support light and dark themes.

### Description
- Added new CSS custom properties under `:root` and `[data-theme='dark']` for `--news-*` color, surface, border, divider, meta, title, body, and shadow tokens.
- Implemented layout and typography styles for `.blog-wrapper`, `.blog-list-page`, and `.blog-post-page` including max-width, spacing, article borders, and headline sizing.
- Styled avatars, metadata, blockquotes, and pagination elements to match the newspaper aesthetic and primary color accents.
- Added responsive adjustments via an `@media (max-width: 996px)` block to adapt padding, font sizes, and border radii on smaller screens.

### Testing
- Ran the static site build with `npm run build` as a smoke check and the build completed successfully.
- Ran CSS linting with `npm run lint:css` and no linting errors were reported.
- Performed a quick local dev server smoke test with `npm start` and verified the blog list and post pages render without console errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df3f90bb788328a2d181f76312db84)